### PR TITLE
Allow objects to be passed as a parameter on the worker-pool method

### DIFF
--- a/lib/worker-pool/index.js
+++ b/lib/worker-pool/index.js
@@ -8,10 +8,14 @@ module.exports = function(options) {
 
 	var workers = farm(options, require.resolve('./worker'));
 
-	return function(fn) {
+	return function(fn, optns) {
 		var code = fn.toString();
+		var params = JSON.stringify({
+			options: optns,
+			fn: code
+		});
 		return function(cb) {
-			workers(code, cb);
+			workers(params, cb);
 		};
 	};
 };

--- a/lib/worker-pool/worker.js
+++ b/lib/worker-pool/worker.js
@@ -13,7 +13,9 @@ function parseFn(str) {
 	return cache[str];
 }
 
-module.exports = function(code, cb) {
-	var fn = parseFn(code);
+module.exports = function(optns, cb) {
+	optns = JSON.parse(optns);
+	var code = optns.fn;
+	var fn = parseFn(code).bind(optns.options);
 	asyncDone(fn, cb);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spawn-task-experiment",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Tests how fast it is to run gulp tasks in child processes",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I was using your module but I found that I would just love to pass the name of the file gulp needed to minify as a parameter. 

I made some modifications in order to do so. Now you can pass a second parameter to the 'makeItFaster' function with some parameters. It's important to notice that I use JSON.stringify, so no functions can be passed.

The parameter is then passed as 'this' to the function.

Code example:

``` js
var makeItFaster = require('spawn-task-experiment').workerPool();

gulp.task('whatever', makeItFaster(function() {
    var gulp = require('gulp');
    var sourcemaps = require('gulp-sourcemaps');
    var concat = require('gulp-concat');

    //We get the name
    var name = this.name;

    return gulp.src(['app/' + name + '.js', 'app/**/*.js'])  //We use name
        .pipe(sourcemaps.init())
        .pipe(concat('all.js'))
        .pipe(sourcemaps.write('.'))
        .pipe(gulp.dest('.build/scripts'));
}), 
{
  name: 'hello'
});
```

PS: This is my first pull request. I hope I did it right.
